### PR TITLE
Update coordinator.py

### DIFF
--- a/custom_components/onkyo/coordinator.py
+++ b/custom_components/onkyo/coordinator.py
@@ -194,7 +194,7 @@ class OnkyoUpdateCoordinator(DataUpdateCoordinator):
         if supports_volume:
             # AMP_VOL/MAX_RECEIVER_VOL*(MAX_VOL/100)
             volume = (
-                volume_raw[1] / self._receiver_max_volume * (self._max_volume / 100)
+                volume_raw[1] / self.receiver_max_volume * (self.max_volume / 100)
             )
             datas.update({"volume": volume})
 


### PR DESCRIPTION
Edited self._receiver_max_volume and self._max_volume to self.receiver_max_volume and self.max_volume to combat error:
DEBUG (MainThread) [custom_components.onkyo.coordinator] 'OnkyoUpdateCoordinator' object has no attribute '_receiver_max_volume'
as mentioned in [Issue #1](https://github.com/cyr-ius/hass-onkyo/issues/1)